### PR TITLE
feat: implement lightweight auto target pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
 # auto-target-pipe
-Constructing auto target prediction pipeline using frame of scDrugPrio and core of Genes2genes and hyperG-VAE,
+
+A lightweight, fully self-contained prototype of an automated therapeutic
+target prediction pipeline.  The implementation follows the high-level idea of
+combining transcriptomic expression signals with relational knowledge from
+Genes2Genes-like interaction graphs and hypergraph-inspired embeddings similar
+to hyperG-VAE.
+
+The repository intentionally avoids heavy third-party dependencies so that the
+core ideas can run in constrained environments (such as this challenge).  The
+pipeline therefore focuses on easy-to-audit Python code backed by unit tests.
+
+## Project layout
+
+```
+src/auto_target_pipe/
+├── data.py           # Sample/experiment data containers
+├── features.py       # Feature extraction orchestration
+├── hypergraph.py     # Hypergraph utilities and encoder
+├── model.py          # Pure-Python logistic regression
+├── network.py        # Gene-gene interaction aggregation
+└── pipeline.py       # High-level AutoTargetPipeline facade
+```
+
+Unit tests live under `tests/` and validate the main workflow.
+
+## Usage
+
+1. Prepare an expression CSV with columns `sample`, `label` and one column per
+gene.
+2. Define a gene network edge list and hypergraph specification for the
+pathways of interest.
+3. Train and evaluate the pipeline as shown below.
+
+```python
+from auto_target_pipe import (
+    AutoTargetPipeline,
+    ExpressionDataset,
+    GeneNetwork,
+    HyperGraph,
+    HyperGraphEncoder,
+    PipelineConfig,
+)
+
+# Load data
+expression = ExpressionDataset.from_csv("expression.csv")
+network = GeneNetwork.from_edges([("G1", "G2"), ("G2", "G3")])
+hypergraph = HyperGraph.from_iterable([["G1", "G3"], ["G2", "G4"]])
+encoder = HyperGraphEncoder(hypergraph, latent_dim=2, seed=42)
+
+# Train the model
+pipeline = AutoTargetPipeline(
+    expression.genes,
+    network=network,
+    encoder=encoder,
+    config=PipelineConfig(learning_rate=0.3, epochs=400, l2_penalty=0.0),
+)
+pipeline.fit(expression)
+
+# Score the training cohort (or a held-out dataset)
+probabilities = pipeline.predict_scores(expression)
+print(probabilities)
+```
+
+## Running tests
+
+```bash
+python -m pytest
+```
+
+The tests exercise CSV ingestion, feature extraction and end-to-end training
+with a synthetic dataset that mimics a Genes2Genes + hyperG-VAE inspired setup.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/auto_target_pipe/__init__.py
+++ b/src/auto_target_pipe/__init__.py
@@ -1,0 +1,20 @@
+"""Core components for the auto-target prediction pipeline."""
+
+from .data import ExpressionDataset, SampleRecord
+from .network import GeneNetwork
+from .hypergraph import HyperGraph, HyperGraphEncoder
+from .features import FeatureExtractor
+from .model import LogisticRegression
+from .pipeline import AutoTargetPipeline, PipelineConfig
+
+__all__ = [
+    "ExpressionDataset",
+    "SampleRecord",
+    "GeneNetwork",
+    "HyperGraph",
+    "HyperGraphEncoder",
+    "FeatureExtractor",
+    "LogisticRegression",
+    "AutoTargetPipeline",
+    "PipelineConfig",
+]

--- a/src/auto_target_pipe/data.py
+++ b/src/auto_target_pipe/data.py
@@ -1,0 +1,125 @@
+"""Data container utilities for the auto target prediction pipeline.
+
+The goal of this module is to keep the representation of experimental samples
+explicit and easy to manipulate.  The implementations rely solely on the
+Python standard library so that the project remains lightweight and portable.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Sequence
+
+
+@dataclass(frozen=True)
+class SampleRecord:
+    """Representation of a single experiment/sample.
+
+    Attributes
+    ----------
+    name:
+        Identifier of the sample.  This is typically a combination of a drug
+        and a condition (e.g. cell type) but the pipeline leaves it generic so
+        it can be adapted to different experimental setups.
+    label:
+        Binary label describing whether the sample is associated with a
+        desirable target response.  The logistic regression model in the
+        pipeline expects ``0`` or ``1``.
+    expression:
+        Mapping from gene symbol to expression value.
+    """
+
+    name: str
+    label: int
+    expression: Dict[str, float]
+
+    def vector(self, genes: Sequence[str]) -> List[float]:
+        """Return the expression values for ``genes`` in the specified order."""
+
+        return [float(self.expression.get(gene, 0.0)) for gene in genes]
+
+
+class ExpressionDataset:
+    """Collection of :class:`SampleRecord` objects with a shared gene space."""
+
+    def __init__(self, genes: Sequence[str], samples: Sequence[SampleRecord]):
+        if not genes:
+            raise ValueError("At least one gene must be provided")
+        self._genes: List[str] = list(genes)
+        self._samples: List[SampleRecord] = list(samples)
+
+    @property
+    def genes(self) -> List[str]:
+        return list(self._genes)
+
+    @property
+    def samples(self) -> List[SampleRecord]:
+        return list(self._samples)
+
+    @property
+    def labels(self) -> List[int]:
+        return [sample.label for sample in self._samples]
+
+    def matrix(self) -> List[List[float]]:
+        """Return a dense matrix of expression values.
+
+        Each row corresponds to a sample and each column corresponds to a gene
+        in the order defined by :pyattr:`genes`.
+        """
+
+        return [sample.vector(self._genes) for sample in self._samples]
+
+    @classmethod
+    def from_records(cls, records: Iterable[SampleRecord]) -> "ExpressionDataset":
+        records = list(records)
+        if not records:
+            raise ValueError("At least one sample record must be provided")
+        genes: Dict[str, None] = {}
+        for record in records:
+            genes.update({gene: None for gene in record.expression})
+        ordered_genes = sorted(genes)
+        return cls(ordered_genes, records)
+
+    @classmethod
+    def from_csv(cls, path: Path | str) -> "ExpressionDataset":
+        """Load an expression dataset from a CSV file.
+
+        The expected format is one sample per row with the following columns:
+
+        ``sample`` (identifier), ``label`` (0 or 1) and one column per gene.
+        """
+
+        csv_path = Path(path)
+        with csv_path.open(newline="", encoding="utf8") as handle:
+            reader = csv.reader(handle)
+            header = next(reader, None)
+            if header is None:
+                raise ValueError("CSV file is empty")
+            if len(header) < 3:
+                raise ValueError("CSV must contain at least sample, label and one gene column")
+            genes = header[2:]
+            samples: List[SampleRecord] = []
+            for row in reader:
+                if not row:
+                    continue
+                sample_name = row[0]
+                label = int(row[1])
+                expression_values = {
+                    gene: float(value) if value else 0.0
+                    for gene, value in zip(genes, row[2:])
+                }
+                samples.append(SampleRecord(sample_name, label, expression_values))
+        return cls(genes, samples)
+
+    def iter_vectors(self) -> Iterator[List[float]]:
+        """Yield the expression vector for each sample."""
+
+        for sample in self._samples:
+            yield sample.vector(self._genes)
+
+    def iter_samples(self) -> Iterator[SampleRecord]:
+        """Iterate over the stored samples."""
+
+        return iter(self._samples)

--- a/src/auto_target_pipe/features.py
+++ b/src/auto_target_pipe/features.py
@@ -1,0 +1,57 @@
+"""Feature construction utilities."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Mapping, Optional, Sequence
+
+from .hypergraph import HyperGraphEncoder
+from .network import GeneNetwork
+
+
+class FeatureExtractor:
+    """Combine raw expression, gene network and hypergraph summaries."""
+
+    def __init__(
+        self,
+        genes: Sequence[str],
+        network: Optional[GeneNetwork] = None,
+        encoder: Optional[HyperGraphEncoder] = None,
+    ):
+        if not genes:
+            raise ValueError("At least one gene must be supplied")
+        self.genes = list(genes)
+        self.network = network
+        self.encoder = encoder
+
+    @staticmethod
+    def _summary(values: Sequence[float]) -> List[float]:
+        if not values:
+            return [0.0, 0.0, 0.0, 0.0]
+        minimum = min(values)
+        maximum = max(values)
+        mean = sum(values) / len(values)
+        variance = 0.0
+        for value in values:
+            variance += (value - mean) ** 2
+        variance /= len(values)
+        std_dev = math.sqrt(variance)
+        return [mean, std_dev, minimum, maximum]
+
+    def transform_sample(self, expression: Mapping[str, float]) -> List[float]:
+        base_values = [float(expression.get(gene, 0.0)) for gene in self.genes]
+        features = self._summary(base_values)
+
+        if self.network is not None:
+            aggregated = self.network.aggregate_expression(expression)
+            aggregated_values = [aggregated.get(gene, 0.0) for gene in self.genes]
+            features.extend(self._summary(aggregated_values))
+        else:
+            features.extend([0.0, 0.0, 0.0, 0.0])
+
+        if self.encoder is not None:
+            features.extend(self.encoder.encode(expression))
+        return features
+
+    def transform(self, dataset) -> List[List[float]]:
+        return [self.transform_sample(sample.expression) for sample in dataset.samples]

--- a/src/auto_target_pipe/hypergraph.py
+++ b/src/auto_target_pipe/hypergraph.py
@@ -1,0 +1,70 @@
+"""Simple hypergraph feature construction inspired by hyperG-VAE."""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Sequence, Set
+
+
+@dataclass(frozen=True)
+class HyperGraph:
+    """Representation of a hypergraph using sets of genes as hyperedges."""
+
+    hyperedges: Sequence[Set[str]]
+
+    @classmethod
+    def from_iterable(cls, hyperedges: Iterable[Iterable[str]]) -> "HyperGraph":
+        edges = [frozenset(edge) for edge in hyperedges if edge]
+        if not edges:
+            raise ValueError("At least one hyperedge must be provided")
+        return cls(edges)
+
+    def aggregate(self, expression: Mapping[str, float]) -> List[float]:
+        """Compute the mean expression per hyperedge."""
+
+        features: List[float] = []
+        for edge in self.hyperedges:
+            if not edge:
+                features.append(0.0)
+                continue
+            total = 0.0
+            for gene in edge:
+                total += float(expression.get(gene, 0.0))
+            features.append(total / len(edge))
+        return features
+
+
+class HyperGraphEncoder:
+    """Project hypergraph features to a compact latent representation."""
+
+    def __init__(self, hypergraph: HyperGraph, latent_dim: int = 4, seed: int = 13):
+        if latent_dim <= 0:
+            raise ValueError("latent_dim must be positive")
+        self.hypergraph = hypergraph
+        self.latent_dim = latent_dim
+        self._projection = self._create_projection(len(hypergraph.hyperedges), latent_dim, seed)
+
+    @staticmethod
+    def _create_projection(num_features: int, latent_dim: int, seed: int) -> List[List[float]]:
+        rng = random.Random(seed)
+        projection: List[List[float]] = []
+        for _ in range(latent_dim):
+            row = []
+            for _ in range(num_features):
+                row.append(rng.uniform(-1.0, 1.0))
+            projection.append(row)
+        return projection
+
+    def encode(self, expression: Mapping[str, float]) -> List[float]:
+        raw_features = self.hypergraph.aggregate(expression)
+        if not raw_features:
+            return [0.0] * self.latent_dim
+        encoded: List[float] = []
+        for row in self._projection:
+            value = 0.0
+            for weight, feature in zip(row, raw_features):
+                value += weight * feature
+            encoded.append(value / math.sqrt(len(raw_features)))
+        return encoded

--- a/src/auto_target_pipe/model.py
+++ b/src/auto_target_pipe/model.py
@@ -1,0 +1,79 @@
+"""A lightweight implementation of logistic regression using gradient descent."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, List, Sequence
+
+
+class LogisticRegression:
+    """Binary logistic regression implemented with batch gradient descent."""
+
+    def __init__(
+        self,
+        learning_rate: float = 0.1,
+        epochs: int = 200,
+        l2_penalty: float = 0.0,
+    ) -> None:
+        if learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+        if epochs <= 0:
+            raise ValueError("epochs must be positive")
+        if l2_penalty < 0:
+            raise ValueError("l2_penalty cannot be negative")
+        self.learning_rate = learning_rate
+        self.epochs = epochs
+        self.l2_penalty = l2_penalty
+        self._weights: List[float] | None = None
+
+    @staticmethod
+    def _sigmoid(x: float) -> float:
+        if x < -50:
+            return 1e-22
+        if x > 50:
+            return 1.0 - 1e-22
+        return 1.0 / (1.0 + math.exp(-x))
+
+    def fit(self, features: Sequence[Sequence[float]], labels: Sequence[int]) -> None:
+        if not features:
+            raise ValueError("No training data supplied")
+        if len(features) != len(labels):
+            raise ValueError("Features and labels must have the same length")
+        num_features = len(features[0])
+        self._weights = [0.0] * (num_features + 1)
+        for epoch in range(self.epochs):
+            gradients = [0.0] * (num_features + 1)
+            for vector, label in zip(features, labels):
+                if len(vector) != num_features:
+                    raise ValueError("Inconsistent feature vector size")
+                activation = self._weights[-1]  # bias
+                for weight, value in zip(self._weights[:-1], vector):
+                    activation += weight * value
+                probability = self._sigmoid(activation)
+                error = probability - float(label)
+                for index, value in enumerate(vector):
+                    gradients[index] += error * value
+                gradients[-1] += error
+            for index in range(num_features):
+                gradients[index] = gradients[index] / len(features) + self.l2_penalty * self._weights[index]
+            gradients[-1] = gradients[-1] / len(features) + self.l2_penalty * self._weights[-1]
+            for index in range(num_features + 1):
+                self._weights[index] -= self.learning_rate * gradients[index]
+
+    def _check_fitted(self) -> List[float]:
+        if self._weights is None:
+            raise RuntimeError("Model has not been fitted yet")
+        return self._weights
+
+    def predict_proba(self, features: Sequence[Sequence[float]]) -> List[float]:
+        weights = self._check_fitted()
+        probabilities: List[float] = []
+        for vector in features:
+            activation = weights[-1]
+            for weight, value in zip(weights[:-1], vector):
+                activation += weight * value
+            probabilities.append(self._sigmoid(activation))
+        return probabilities
+
+    def predict(self, features: Sequence[Sequence[float]], threshold: float = 0.5) -> List[int]:
+        return [1 if probability >= threshold else 0 for probability in self.predict_proba(features)]

--- a/src/auto_target_pipe/network.py
+++ b/src/auto_target_pipe/network.py
@@ -1,0 +1,69 @@
+"""Minimal gene-gene interaction network utilities."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+
+class GeneNetwork:
+    """Representation of an undirected gene interaction graph."""
+
+    def __init__(self, adjacency: Mapping[str, Sequence[Tuple[str, float]]]):
+        self._adjacency: Dict[str, List[Tuple[str, float]]] = {
+            gene: list(neighbours) for gene, neighbours in adjacency.items()
+        }
+        for gene, neighbours in list(self._adjacency.items()):
+            for neighbour, weight in neighbours:
+                if neighbour not in self._adjacency:
+                    self._adjacency[neighbour] = []
+                if gene not in {g for g, _ in self._adjacency[neighbour]}:
+                    self._adjacency[neighbour].append((gene, weight))
+
+    @classmethod
+    def from_edges(
+        cls, edges: Iterable[Tuple[str, str, float]] | Iterable[Tuple[str, str]]
+    ) -> "GeneNetwork":
+        """Construct the network from an edge list.
+
+        If weights are omitted they default to ``1.0``.
+        """
+
+        adjacency: MutableMapping[str, List[Tuple[str, float]]] = defaultdict(list)
+        for edge in edges:
+            if len(edge) == 2:
+                left, right = edge  # type: ignore[misc]
+                weight = 1.0
+            else:
+                left, right, weight = edge  # type: ignore[misc]
+            adjacency[left].append((right, float(weight)))
+            adjacency[right].append((left, float(weight)))
+        return cls(adjacency)
+
+    def aggregate_expression(self, expression: Mapping[str, float]) -> Dict[str, float]:
+        """Aggregate neighbour expression for each gene.
+
+        The aggregation is a weighted average of a gene's neighbours.  Genes
+        without neighbours simply reuse their own expression value.
+        """
+
+        aggregated: Dict[str, float] = {}
+        for gene, neighbours in self._adjacency.items():
+            if not neighbours:
+                aggregated[gene] = float(expression.get(gene, 0.0))
+                continue
+            total_weight = sum(weight for _, weight in neighbours)
+            if total_weight == 0.0:
+                aggregated[gene] = 0.0
+                continue
+            score = 0.0
+            for neighbour, weight in neighbours:
+                score += float(expression.get(neighbour, 0.0)) * weight
+            aggregated[gene] = score / total_weight
+        return aggregated
+
+    def degree(self, gene: str) -> int:
+        return len(self._adjacency.get(gene, ()))
+
+    def genes(self) -> List[str]:
+        return sorted(self._adjacency)

--- a/src/auto_target_pipe/pipeline.py
+++ b/src/auto_target_pipe/pipeline.py
@@ -1,0 +1,54 @@
+"""High-level orchestration of the auto target prediction workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .data import ExpressionDataset
+from .features import FeatureExtractor
+from .hypergraph import HyperGraphEncoder
+from .model import LogisticRegression
+from .network import GeneNetwork
+
+
+@dataclass
+class PipelineConfig:
+    learning_rate: float = 0.1
+    epochs: int = 300
+    l2_penalty: float = 0.01
+
+
+class AutoTargetPipeline:
+    """Combine feature extraction and model training into a single interface."""
+
+    def __init__(
+        self,
+        genes,
+        network: Optional[GeneNetwork] = None,
+        encoder: Optional[HyperGraphEncoder] = None,
+        config: PipelineConfig | None = None,
+    ) -> None:
+        self.config = config or PipelineConfig()
+        self.extractor = FeatureExtractor(genes, network=network, encoder=encoder)
+        self.model = LogisticRegression(
+            learning_rate=self.config.learning_rate,
+            epochs=self.config.epochs,
+            l2_penalty=self.config.l2_penalty,
+        )
+        self._fitted = False
+
+    def fit(self, dataset: ExpressionDataset) -> None:
+        features = self.extractor.transform(dataset)
+        self.model.fit(features, dataset.labels)
+        self._fitted = True
+
+    def predict_scores(self, dataset: ExpressionDataset) -> list[float]:
+        if not self._fitted:
+            raise RuntimeError("Pipeline must be fitted before prediction")
+        features = self.extractor.transform(dataset)
+        return self.model.predict_proba(features)
+
+    def predict_labels(self, dataset: ExpressionDataset, threshold: float = 0.5) -> list[int]:
+        scores = self.predict_scores(dataset)
+        return [1 if score >= threshold else 0 for score in scores]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from auto_target_pipe import (
+    AutoTargetPipeline,
+    ExpressionDataset,
+    GeneNetwork,
+    HyperGraph,
+    HyperGraphEncoder,
+    PipelineConfig,
+    SampleRecord,
+)
+from auto_target_pipe.features import FeatureExtractor
+
+
+def build_dataset() -> ExpressionDataset:
+    positives = [
+        SampleRecord("p1", 1, {"G1": 3.1, "G2": 2.8, "G3": 3.0, "G4": 2.6}),
+        SampleRecord("p2", 1, {"G1": 3.3, "G2": 2.9, "G3": 3.2, "G4": 2.4}),
+        SampleRecord("p3", 1, {"G1": 3.2, "G2": 2.7, "G3": 3.1, "G4": 2.5}),
+    ]
+    negatives = [
+        SampleRecord("n1", 0, {"G1": 0.3, "G2": 0.7, "G3": 0.4, "G4": 0.6}),
+        SampleRecord("n2", 0, {"G1": 0.2, "G2": 0.6, "G3": 0.3, "G4": 0.5}),
+        SampleRecord("n3", 0, {"G1": 0.1, "G2": 0.8, "G3": 0.2, "G4": 0.4}),
+    ]
+    return ExpressionDataset.from_records(positives + negatives)
+
+
+def test_dataset_from_csv(tmp_path: Path) -> None:
+    csv_path = tmp_path / "expression.csv"
+    csv_path.write_text(
+        "sample,label,G1,G2,G3,G4\n"
+        "s1,1,1.0,2.0,3.0,4.0\n"
+        "s2,0,0.1,0.2,0.3,0.4\n",
+        encoding="utf8",
+    )
+    dataset = ExpressionDataset.from_csv(csv_path)
+    assert dataset.genes == ["G1", "G2", "G3", "G4"]
+    assert dataset.labels == [1, 0]
+    assert dataset.matrix() == [[1.0, 2.0, 3.0, 4.0], [0.1, 0.2, 0.3, 0.4]]
+
+
+def test_feature_extraction_shapes() -> None:
+    dataset = build_dataset()
+    network = GeneNetwork.from_edges([("G1", "G2"), ("G3", "G4")])
+    hypergraph = HyperGraph.from_iterable([["G1", "G3"], ["G2", "G4"]])
+    encoder = HyperGraphEncoder(hypergraph, latent_dim=3, seed=7)
+    extractor = FeatureExtractor(dataset.genes, network=network, encoder=encoder)
+    sample_features = extractor.transform_sample(dataset.samples[0].expression)
+    assert len(sample_features) == 4 + 4 + 3
+    assert not math.isnan(sample_features[0])
+
+
+def test_pipeline_training_and_prediction() -> None:
+    dataset = build_dataset()
+    network = GeneNetwork.from_edges([("G1", "G2"), ("G2", "G3"), ("G3", "G4")])
+    hypergraph = HyperGraph.from_iterable([["G1", "G3", "G4"], ["G2", "G3"]])
+    encoder = HyperGraphEncoder(hypergraph, latent_dim=2, seed=11)
+    pipeline = AutoTargetPipeline(
+        dataset.genes,
+        network=network,
+        encoder=encoder,
+        config=PipelineConfig(learning_rate=0.5, epochs=500, l2_penalty=0.0),
+    )
+    pipeline.fit(dataset)
+    scores = pipeline.predict_scores(dataset)
+    predictions = pipeline.predict_labels(dataset, threshold=0.5)
+    assert len(scores) == len(dataset.samples)
+    assert all(0.0 <= score <= 1.0 for score in scores)
+    accuracy = sum(int(pred == label) for pred, label in zip(predictions, dataset.labels)) / len(predictions)
+    assert accuracy >= 0.83


### PR DESCRIPTION
## Summary
- add a pure-Python auto target pipeline package covering data handling, feature extraction, and model training
- document usage and project layout while ignoring Python bytecode artefacts
- add pytest configuration and unit tests that exercise the end-to-end workflow

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68da388c88788331b1d8385349b3863c